### PR TITLE
use [ instead of [[

### DIFF
--- a/restart.sh
+++ b/restart.sh
@@ -15,7 +15,7 @@ set -u
 
 touch restart.txt
 PID="$(cat process.txt)"
-if [[ $? -ne 0 ]]; then
+if [ $? -ne 0 ]; then
   echo "unable to read process.txt. was your process started with start.sh?"
   exit 1
 fi


### PR DESCRIPTION
Fixes #4 

The error was as follows:

```
./restart.sh: 18: ./restart.sh: [[: not found
```

Signed-off-by: Chuck Ha <chuckh@vmware.com>