### PR TITLE
update readme to not reference restart_container, provide unsupported cases [ch7449]

### DIFF
--- a/restart.sh
+++ b/restart.sh
@@ -1,6 +1,9 @@
 #!/bin/sh
 #
-# A helper script to implement restart_container when the docker runtime isn't available.
+# A helper script to restart a given process as part of a Live Update.
+#
+# Further reading:
+# https://docs.tilt.dev/live_update_reference.html#restarting-your-process
 #
 # Usage:
 #   Copy start.sh and restart.sh to your container working dir.

--- a/start.sh
+++ b/start.sh
@@ -1,6 +1,9 @@
 #!/bin/sh
 #
-# A helper script to implement restart_container when the docker runtime isn't available.
+# A helper script to restart a given process as part of a Live Update.
+#
+# Further reading:
+# https://docs.tilt.dev/live_update_reference.html#restarting-your-process
 #
 # Usage:
 #   Copy start.sh and restart.sh to your container working dir.


### PR DESCRIPTION
Hello @nicks, @ellenkorbes,

Please review the following commits I made in branch maiamcc/readme:

587d672102a0c734b73c87ab716844b5f5afc833 (2020-06-10 17:07:34 -0400)
update script comments

f20305b3a1f82a650eaaa99f26abdbb15c6a3e54 (2020-06-10 16:36:54 -0400)
update readme to not reference restart_container, provide unsupported cases [ch7449]

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics